### PR TITLE
Modify name split for names with no path separator

### DIFF
--- a/src/main/java/com/mulesoft/services/tools/sonarqube/metrics/CoverageSensor.java
+++ b/src/main/java/com/mulesoft/services/tools/sonarqube/metrics/CoverageSensor.java
@@ -108,7 +108,11 @@ public class CoverageSensor implements Sensor {
 						}
 					}
 				}
-				String[] fileParts = name.split(File.separator);
+				String[] fileParts;
+				if (name.contains(File.separator))
+					fileParts = name.split(File.separator);
+				else
+					fileParts = new String[] { name };
 				coverageMap.put(fileParts[fileParts.length - 1], counter);
 				if (logger.isDebugEnabled()) {
 					logger.debug("name :" + node.get("name") + " : coverage:" + node.get("coverage"));


### PR DESCRIPTION
* Modify name split for names that have no path separator.

JSON coverage reports can have a name that does not have any file separators as shown below.

![image](https://user-images.githubusercontent.com/17272329/90959153-19a73200-e491-11ea-800f-c35d59d47f6e.png)

Without the name check the Maven scanner will stop with a build exception. JSON coverage report generated from AnyPoint Studio 7.5.1 and Mule 4.2.1.
