### PR TITLE
Added Is Configurable Check.

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,6 +132,14 @@ For example, the rule store (rules-4.xml) has three rulesets (categories):
             or
             matches(//mule:mule/mule:flow/ee:transform/ee:message/ee:set-payload/@resource,'^.*dwl$')
         </rule>
+        <rule id="2"
+			name="Mule Credentials Vault should not use a hardcoded encryption key"
+			description="Mule Credentials Vault should not use a hardcoded encryption key"
+			severity="MAJOR" type="bug">
+			count(//mule:mule/secure-properties:config)=0
+			or
+			is-configurable(//mule:mule/secure-properties:config/@key)
+		</rule>
     </ruleset>
 </rulestore>
 ```

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
 	<groupId>com.mulesoft.services</groupId>
 	<artifactId>mule-validation-sonarqube-plugin</artifactId>
-	<version>1.0.3</version>
+	<version>1.0.4</version>
 	<packaging>jar</packaging>
 
 	<url>http://maven.apache.org</url>

--- a/src/main/java/com/mulesoft/services/tools/sonarqube/measures/MuleTransformationCount.java
+++ b/src/main/java/com/mulesoft/services/tools/sonarqube/measures/MuleTransformationCount.java
@@ -26,11 +26,11 @@ public class MuleTransformationCount implements MeasureComputer {
 		logger.info("Computing Mule Transformation Count");
 
 		if (context.getComponent().getType() != Component.Type.FILE) {
-			int sumFlows = 0;
+			int sumTransformations = 0;
 			for (Measure child : context.getChildrenMeasures(MuleMetrics.TRANSFORMATIONS.key())) {
-				sumFlows += child.getIntValue();
+				sumTransformations += child.getIntValue();
 			}
-			context.addMeasure(MuleMetrics.TRANSFORMATIONS.key(), sumFlows);
+			context.addMeasure(MuleMetrics.TRANSFORMATIONS.key(), sumTransformations);
 
 		}
 

--- a/src/main/java/com/mulesoft/services/xpath/XPathProcessor.java
+++ b/src/main/java/com/mulesoft/services/xpath/XPathProcessor.java
@@ -16,6 +16,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import com.mulesoft.services.xpath.jaxen.function.ext.MatchesFunction;
+import com.mulesoft.services.xpath.jaxen.function.ext.IsConfigurableFunction;
 
 public class XPathProcessor {
 	Logger logger = LoggerFactory.getLogger(getClass());
@@ -26,6 +27,7 @@ public class XPathProcessor {
 
 	public XPathProcessor() {
 		MatchesFunction.registerSelfInSimpleContext();
+		IsConfigurableFunction.registerSelfInSimpleContext();
 	}
 
 	public XPathProcessor loadNamespaces(String resourceName) {

--- a/src/main/java/com/mulesoft/services/xpath/jaxen/function/ext/IsConfigurableFunction.java
+++ b/src/main/java/com/mulesoft/services/xpath/jaxen/function/ext/IsConfigurableFunction.java
@@ -11,25 +11,27 @@ import org.jaxen.SimpleFunctionContext;
 import org.jaxen.XPathFunctionContext;
 import org.jaxen.function.StringFunction;
 
-public class MatchesFunction implements Function {
+public class IsConfigurableFunction implements Function {
+
+	private static final String IS_CONFIGURABLE_REGEX = "^\\$\\{.*\\}$";
 
 	public static void registerSelfInSimpleContext() {
 		// see http://jaxen.org/extensions.html
-		((SimpleFunctionContext) XPathFunctionContext.getInstance()).registerFunction(null, "matches",
-				new MatchesFunction());
+		((SimpleFunctionContext) XPathFunctionContext.getInstance()).registerFunction(null, "is-configurable",
+				new IsConfigurableFunction());
 	}
 
 	@Override
 	public Object call(Context context, List args) throws FunctionCallException {
 
-		if (args.size() == 2) {
-			return evaluate(args.get(0), args.get(1), context.getNavigator());
+		if (args.size() == 1) {
+			return evaluate(args.get(0), context.getNavigator());
 		}
 
-		throw new FunctionCallException("matches() requires two arguments.");
+		throw new FunctionCallException("is-configurable() requires two arguments.");
 	}
 
-	public static Boolean evaluate(Object strArg, Object matchArg, Navigator nav) {
+	public static Boolean evaluate(Object strArg, Navigator nav) {
 		if (strArg instanceof List) {
 			@SuppressWarnings("unchecked")
 			List<Object> objectList = (List<Object>) strArg;
@@ -41,7 +43,9 @@ public class MatchesFunction implements Function {
 			for (Iterator<Object> iterator = objectList.iterator(); iterator.hasNext();) {
 				Object object = iterator.next();
 				String str = StringFunction.evaluate(object, nav);
-				String regexp = StringFunction.evaluate(matchArg, nav);
+				String regexp = StringFunction.evaluate(IS_CONFIGURABLE_REGEX, nav);
+				System.out.println("str: " + str);
+				System.out.println("regexp: " + regexp);
 				if (!str.matches(regexp)) {
 					return Boolean.FALSE;
 				}
@@ -49,7 +53,7 @@ public class MatchesFunction implements Function {
 			return Boolean.TRUE;
 		} else {
 			String str = StringFunction.evaluate(strArg, nav);
-			String regexp = StringFunction.evaluate(matchArg, nav);
+			String regexp = StringFunction.evaluate(IS_CONFIGURABLE_REGEX, nav);
 			return (str.matches(regexp) ? Boolean.TRUE : Boolean.FALSE);
 		}
 

--- a/src/test/java/com/mulesoft/services/tools/validation/Mule4Test.java
+++ b/src/test/java/com/mulesoft/services/tools/validation/Mule4Test.java
@@ -58,4 +58,14 @@ public class Mule4Test {
 		boolean valid = xpathProcessor.processXPath(rule, rootElement, Boolean.class).booleanValue();
 		assertTrue("HTTP Requestor Configuration should have a configurable Response Timeout", valid);
 	}
+
+	@Test
+	public void testIsConfigurable() throws JDOMException, IOException {
+		String rule = "is-configurable(//mule:mule/secure-properties:config/@key)";
+		String fileName = testDirectory.concat(File.separator + "global.xml");
+		Document document = saxBuilder.build(new File(fileName));
+		Element rootElement = document.getRootElement();
+		boolean valid = xpathProcessor.processXPath(rule, rootElement, Boolean.class).booleanValue();
+		assertTrue("MULE CREDENTIALS MUST BE CONFIGURABLE", valid);
+	}
 }


### PR DESCRIPTION
Background:
We found that when creating rules, we wanted to ensure that we're not hardcoding attributes eg. secure properties, http response timeout, http connection idle.
For this, we added a lot of matches(attr, "${}") regexes.

Feature:
We thought of creating a function that handles checking if a property is configurable ie."${}".

Fix spelling mistake and incorrect variable definitions.