### PR TITLE
Updated log4j-slf4j-impl to 2.17.0. 

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -54,7 +54,7 @@
 		<dependency>
 			<groupId>org.apache.logging.log4j</groupId>
 			<artifactId>log4j-slf4j-impl</artifactId>
-			<version>2.16.0</version>
+			<version>2.17.0</version>
 		</dependency>
 		<dependency>
 			<groupId>jaxen</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -30,7 +30,7 @@
 		<dependency>
 			<groupId>org.sonarsource.sonarqube</groupId>
 			<artifactId>sonar-plugin-api</artifactId>
-			<!-- minimal version of SonarQube to support. Note that the groupId was 
+			<!-- minimal version of SonarQube to support. Note that the groupId was
 				"org.codehaus.sonar" before version 5.2 -->
 			<version>${sonar.apiVersion}</version>
 			<!-- mandatory scope -->
@@ -54,7 +54,7 @@
 		<dependency>
 			<groupId>org.apache.logging.log4j</groupId>
 			<artifactId>log4j-slf4j-impl</artifactId>
-			<version>2.10.0</version>
+			<version>2.16.0</version>
 		</dependency>
 		<dependency>
 			<groupId>jaxen</groupId>
@@ -100,7 +100,7 @@
 					<pluginClass>com.mulesoft.services.tools.sonarqube.MulePlugin</pluginClass>
 					<pluginName>MulePlugin</pluginName>
 					<pluginKey>mulevalidationsonarqubeplugin-mule</pluginKey>
-					<!-- advanced properties can be set here. See paragraph "Advanced Build 
+					<!-- advanced properties can be set here. See paragraph "Advanced Build
 						Properties". -->
 				</configuration>
 			</plugin>


### PR DESCRIPTION
Tenable reports that log4j-core-2.10.0 has a critical exploit. Updated to latest version 2.16.0. Note that Nessus has not tested for these issues but has instead relied only on the application's self-reported version number.

Example of reported location:

`Path              : /root/.sonar/cache/6b2322bbcb852460079e724f7f542715f/sonar-mulevalidationsonarqubepluginmule-plugin.jar_unzip/META-INF/lib/log4j-core-2.10.0.jar
  Installed version : 2.10.0
  Fixed version     : 2.15.0`
