### PR TITLE
Log4j updated to 2.17.1 for CVE-2021-44832

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -54,7 +54,7 @@
 		<dependency>
 			<groupId>org.apache.logging.log4j</groupId>
 			<artifactId>log4j-slf4j-impl</artifactId>
-			<version>2.17.0</version>
+			<version>2.17.1</version>
 		</dependency>
 		<dependency>
 			<groupId>jaxen</groupId>


### PR DESCRIPTION
We should use the latest log4j to avoid security alerts when using this plugin.

Closes as well #43