### PR TITLE
Change log level for compute() logs from INFO to DEBUG. 

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 	<groupId>com.mulesoft.services</groupId>
 	<artifactId>mule-validation-sonarqube-plugin</artifactId>
 	<version>1.0.6</version>
-	<packaging>jar</packaging>
+	<packaging>sonar-plugin</packaging>
 
 	<url>http://maven.apache.org</url>
 	<description>Sonar Plugin for Mule Projects</description>
@@ -55,6 +55,7 @@
 			<groupId>org.apache.logging.log4j</groupId>
 			<artifactId>log4j-slf4j-impl</artifactId>
 			<version>2.17.2</version>
+			<scope>provided</scope>
 		</dependency>
 		<dependency>
 			<groupId>jaxen</groupId>

--- a/src/main/java/com/mulesoft/services/tools/sonarqube/measures/MuleFlowCount.java
+++ b/src/main/java/com/mulesoft/services/tools/sonarqube/measures/MuleFlowCount.java
@@ -24,7 +24,9 @@ public class MuleFlowCount implements MeasureComputer {
 
 	@Override
 	public void compute(MeasureComputerContext context) {
-		logger.info("Computing Mule Flow Size");
+		if (logger.isDebugEnabled()) {
+			logger.debug("Computing Mule Flow Size");
+		}
 
 		if (context.getComponent().getType() != Component.Type.FILE) {
 			int sumFlows = 0;

--- a/src/main/java/com/mulesoft/services/tools/sonarqube/measures/MuleSizeRating.java
+++ b/src/main/java/com/mulesoft/services/tools/sonarqube/measures/MuleSizeRating.java
@@ -29,7 +29,10 @@ public class MuleSizeRating implements MeasureComputer {
 
 	@Override
 	public void compute(MeasureComputerContext context) {
-		logger.info("Computing MuleSizeRating");
+		if (logger.isDebugEnabled()) {
+			logger.debug("Computing MuleSizeRating");
+
+		}
 		Measure flows = context.getMeasure(MuleMetrics.FLOWS.key());
 		Measure subflows = context.getMeasure(MuleMetrics.SUBFLOWS.key());
 		int totalNumberOfFlows = 0;

--- a/src/main/java/com/mulesoft/services/tools/sonarqube/measures/MuleSubFlowCount.java
+++ b/src/main/java/com/mulesoft/services/tools/sonarqube/measures/MuleSubFlowCount.java
@@ -24,7 +24,9 @@ public class MuleSubFlowCount implements MeasureComputer {
 
 	@Override
 	public void compute(MeasureComputerContext context) {
-		logger.info("Computing Mule SubFlow Size");
+		if (logger.isDebugEnabled()) {
+			logger.debug("Computing Mule SubFlow Size");
+		}
 
 		if (context.getComponent().getType() != Component.Type.FILE) {
 			int sumFlows = 0;

--- a/src/main/java/com/mulesoft/services/tools/sonarqube/measures/MuleTransformationCount.java
+++ b/src/main/java/com/mulesoft/services/tools/sonarqube/measures/MuleTransformationCount.java
@@ -23,7 +23,9 @@ public class MuleTransformationCount implements MeasureComputer {
 
 	@Override
 	public void compute(MeasureComputerContext context) {
-		logger.info("Computing Mule Transformation Count");
+		if (logger.isDebugEnabled()) {
+			logger.debug("Computing Mule Transformation Count");
+		}
 
 		if (context.getComponent().getType() != Component.Type.FILE) {
 			int sumTransformations = 0;


### PR DESCRIPTION
Too much logs are generated for INFO. 50+ messages per second are displayed in the logs. 
Those kind of logs should be generated at DEBUG level, it's not important, I think it's more for debugging purpose.

Thank you to validate it.
Regards.
