### PR TITLE
Fix Plugin URL

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -8,7 +8,7 @@
 	<version>1.0.6</version>
 	<packaging>jar</packaging>
 
-	<url>http://maven.apache.org</url>
+	<url>https://github.com/mulesoft-catalyst/mule-sonarqube-plugin</url>
 	<description>Sonar Plugin for Mule Projects</description>
 
 


### PR DESCRIPTION
Fix Plugin URL, used in Marketplace Homepage link.

![image](https://github.com/mulesoft-catalyst/mule-sonarqube-plugin/assets/14133068/0792e6fe-17e6-4a71-9668-ab2c14002a0c)