### PR TITLE
Exit from MuleSizeRating when it's file-component

### DIFF
--- a/src/main/java/com/mulesoft/services/tools/sonarqube/measures/MuleFlowCount.java
+++ b/src/main/java/com/mulesoft/services/tools/sonarqube/measures/MuleFlowCount.java
@@ -1,5 +1,7 @@
 package com.mulesoft.services.tools.sonarqube.measures;
 
+import java.util.Iterator;
+
 import org.sonar.api.ce.measure.Component;
 import org.sonar.api.ce.measure.Measure;
 import org.sonar.api.ce.measure.MeasureComputer;
@@ -24,16 +26,17 @@ public class MuleFlowCount implements MeasureComputer {
 
 	@Override
 	public void compute(MeasureComputerContext context) {
-		logger.info("Computing Mule Flow Size");
-
-		if (context.getComponent().getType() != Component.Type.FILE) {
-			int sumFlows = 0;
-			for (Measure child : context.getChildrenMeasures(MuleMetrics.FLOWS.key())) {
-				sumFlows += child.getIntValue();
-			}
-			context.addMeasure(MuleMetrics.FLOWS.key(), sumFlows);
-
+		if (context.getComponent().getType() == Component.Type.FILE) {
+			return;
 		}
+
+		logger.debug("Computing Mule Flow Size");
+
+        int sumFlows = 0;
+        for (Measure child : context.getChildrenMeasures(MuleMetrics.FLOWS.key())) {
+            sumFlows += child.getIntValue();
+        }
+        context.addMeasure(MuleMetrics.FLOWS.key(), sumFlows);
 	}
 
 }

--- a/src/main/java/com/mulesoft/services/tools/sonarqube/measures/MuleSizeRating.java
+++ b/src/main/java/com/mulesoft/services/tools/sonarqube/measures/MuleSizeRating.java
@@ -1,5 +1,6 @@
 package com.mulesoft.services.tools.sonarqube.measures;
 
+import org.sonar.api.ce.measure.Component;
 import org.sonar.api.ce.measure.Measure;
 import org.sonar.api.ce.measure.MeasureComputer;
 import org.sonar.api.utils.log.Logger;
@@ -29,8 +30,13 @@ public class MuleSizeRating implements MeasureComputer {
 
 	@Override
 	public void compute(MeasureComputerContext context) {
-		logger.info("Computing MuleSizeRating");
-		Measure flows = context.getMeasure(MuleMetrics.FLOWS.key());
+		if (context.getComponent().getType() == Component.Type.FILE) {
+			return;
+		}
+
+        logger.debug("Computing MuleSizeRating");
+
+        Measure flows = context.getMeasure(MuleMetrics.FLOWS.key());
 		Measure subflows = context.getMeasure(MuleMetrics.SUBFLOWS.key());
 		int totalNumberOfFlows = 0;
 		if (flows != null) {
@@ -40,7 +46,6 @@ public class MuleSizeRating implements MeasureComputer {
 			totalNumberOfFlows += subflows.getIntValue();
 		}
 
-		// rating values are currently implemented as integers in API
 		int rating = RATING_A;
 		if (totalNumberOfFlows > THRESHOLD_SIMPLE) {
 			rating = RATING_B;

--- a/src/main/java/com/mulesoft/services/tools/sonarqube/measures/MuleSubFlowCount.java
+++ b/src/main/java/com/mulesoft/services/tools/sonarqube/measures/MuleSubFlowCount.java
@@ -1,5 +1,7 @@
 package com.mulesoft.services.tools.sonarqube.measures;
 
+import java.util.Iterator;
+
 import org.sonar.api.ce.measure.Component;
 import org.sonar.api.ce.measure.Measure;
 import org.sonar.api.ce.measure.MeasureComputer;
@@ -24,14 +26,16 @@ public class MuleSubFlowCount implements MeasureComputer {
 
 	@Override
 	public void compute(MeasureComputerContext context) {
-		logger.info("Computing Mule SubFlow Size");
-
-		if (context.getComponent().getType() != Component.Type.FILE) {
-			int sumFlows = 0;
-			for (Measure child : context.getChildrenMeasures(MuleMetrics.SUBFLOWS.key())) {
-				sumFlows += child.getIntValue();
-			}
-			context.addMeasure(MuleMetrics.SUBFLOWS.key(), sumFlows);
+		if (context.getComponent().getType() == Component.Type.FILE) {
+			return;
 		}
+
+        logger.debug("Computing Mule SubFlow Size");
+
+        int sumFlows = 0;
+        for (Measure child : context.getChildrenMeasures(MuleMetrics.SUBFLOWS.key())) {
+            sumFlows += child.getIntValue();
+        }
+        context.addMeasure(MuleMetrics.SUBFLOWS.key(), sumFlows);
 	}
 }

--- a/src/main/java/com/mulesoft/services/tools/sonarqube/measures/MuleTransformationCount.java
+++ b/src/main/java/com/mulesoft/services/tools/sonarqube/measures/MuleTransformationCount.java
@@ -1,5 +1,7 @@
 package com.mulesoft.services.tools.sonarqube.measures;
 
+import java.util.Iterator;
+
 import org.sonar.api.ce.measure.Component;
 import org.sonar.api.ce.measure.Measure;
 import org.sonar.api.ce.measure.MeasureComputer;
@@ -23,17 +25,17 @@ public class MuleTransformationCount implements MeasureComputer {
 
 	@Override
 	public void compute(MeasureComputerContext context) {
-		logger.info("Computing Mule Transformation Count");
-
-		if (context.getComponent().getType() != Component.Type.FILE) {
-			int sumTransformations = 0;
-			for (Measure child : context.getChildrenMeasures(MuleMetrics.TRANSFORMATIONS.key())) {
-				sumTransformations += child.getIntValue();
-			}
-			context.addMeasure(MuleMetrics.TRANSFORMATIONS.key(), sumTransformations);
-
+		if (context.getComponent().getType() == Component.Type.FILE) {
+			return;
 		}
 
+        logger.debug("Computing Mule Transformation Count");
+
+        int sumTransformations = 0;
+        for (Measure child : context.getChildrenMeasures(MuleMetrics.TRANSFORMATIONS.key())) {
+            sumTransformations += child.getIntValue();
+        }
+        context.addMeasure(MuleMetrics.TRANSFORMATIONS.key(), sumTransformations);
 	}
 
 }


### PR DESCRIPTION
**MeasureComputers run on the server (CE) for every component**

`MuleFlowCount`, `MuleSubFlowCount`, `MuleTransformationCount`, and `MuleSizeRating` are registered in the plugin and are always executed by the Compute Engine for every component (project, modules, directories, files). 

They don’t see the “file suffixes” setting and can’t be turned off per project. So you still see “Computing Mule Flow Size”, etc., even when the project has no Mule files.

The `MuleSizeRating` has no FILE type check. It calls addMeasure() for every file in the project - including all the Java/XML/Apex/etc. files. 

For a huge non-Mule project with say 100,000 files, it produces:
`100,000 × getMeasure(flows) + getMeasure(subflows)` DB lookups (return null, but still execute)

To fix the problem two guards applied:
1) `FILE` type early exit to avoid calling `getMeasure()` and call db 
2) `flows == null && subflows == null` exit — for non-Mule projects, directory/module-level nodes also have no aggregated FLOWS/SUBFLOWS, so they get skipped entirely without writing a useless rating measure.
